### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/IrieTech500/IrieTech/security/code-scanning/1](https://github.com/IrieTech500/IrieTech/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository and runs scripts, it only needs `contents: read` permission. This ensures that the workflow does not inadvertently gain unnecessary write access.

The `permissions` block will be added immediately after the `name` field (line 3) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
